### PR TITLE
feat: change ring to ship-show-ask

### DIFF
--- a/radar/casavo-tech-radar.json
+++ b/radar/casavo-tech-radar.json
@@ -442,7 +442,7 @@
   },
   {
     "name": "Ship / Show / Ask",
-    "ring": "trial",
+    "ring": "hold",
     "quadrant": "techniques",
     "isNew": "FALSE",
     "description": "A branching strategy that combines the features of Pull Requests with the ability to keep shipping changes. Changes are categorized as either Ship (merge into mainline without review), Show (open a pull request for review, but merge into mainline immediately), or Ask (open a pull request for discussion before merging) -- from https://martinfowler.com/articles/ship-show-ask.html"


### PR DESCRIPTION
i put this on hold just to start the discussion. It was on assess before.
It is something that we explicitly do/want to do? 
On my side i can say that on tribe brokers we always use PRs to do knowledge sharing and to discuss (like we are doing here for example)
Since we have protection on the main branch, we cannot ship directly to main.