### PR TITLE
feat: adopt collective ownership

### DIFF
--- a/radar/casavo-tech-radar.json
+++ b/radar/casavo-tech-radar.json
@@ -469,6 +469,13 @@
     "description": "As in eXtreme Programming definition, teams must have common sets of coding practice, allowing to understand code with ease and encouraging collective ownership"
   },
   {
+    "name": "Collective Ownership",
+    "ring": "adopt",
+    "quadrant": "techniques",
+    "isNew": "FALSE",
+    "description": "encourages everyone to contribute new ideas to all segments of a project, meaning also projects not in the scope of the team. This is tightly coupled with coding standards and translates, for example, in having clear service name and meaningful READMEs"
+  },
+  {
     "name": "Domain-Driven Design",
     "ring": "adopt",
     "quadrant": "techniques",


### PR DESCRIPTION
Not sure if the naming is the best one, but the intention is to define a practice in which we are crystal clear in our communication. 
Having repos without readmes, or with incomplete ones is not acceptable if we want to build a company in which we cooperate at each level. 
Another example is the naming of the services. If we look at AppSales example, they are generic enough but not necessarily using pokemon names or acronims
What is your feeling about this?